### PR TITLE
Batch of Fixes - Training Cap, NPC Quick Build and a bit more

### DIFF
--- a/src/module/actor/character/document.js
+++ b/src/module/actor/character/document.js
@@ -10,6 +10,45 @@ class PTUTrainerActor extends PTUActor {
         return ["feat", "edge", "move", "contestmove", "ability", "item", "capability", "effect", "condition", "dexentry"]
     }
 
+    /**
+     * Get EXP Training data without side effects and duplicating other data effects
+     * Calculates trainer level and milestone data for Pokemon EXP Training Level Cap
+     * @returns {Object} Object with level, milestones, milestoneMultiplier, and expTrainingLevelCap
+     */
+    getExpTrainingData() {
+        // Calculate trainer level using the same logic as prepareBaseData
+        const levelUpRequirement = game.settings.get("ptu", "variant.trainerAdvancement") === "short-track" ? 20 : 10;
+        const maxLevel = {
+            "original": 50,
+            "data-revamp": 25,
+            "short-track": 25,
+            "ptr-update": 50,
+            "long-track": 100,
+        };
+        
+        const dexexp = game.settings.get("ptu", "variant.useDexExp") == true
+            ? (this.system.dex?.owned?.length || 0)
+            : 0;
+        
+        const level = Math.clamp(
+            1
+            + Number(this.system.level.milestones)
+            + Math.trunc((Number(this.system.level.miscexp) / levelUpRequirement) + (Number(dexexp) / levelUpRequirement)),
+            1,
+            maxLevel[game.settings.get("ptu", "variant.trainerAdvancement")] ?? 50
+        );
+        
+        const milestones = this.system.level.milestones;
+        const milestoneMultiplier = 2 + (2 * milestones);
+        
+        return {
+            level,
+            milestones,
+            milestoneMultiplier,
+            expTrainingLevelCap: level * milestoneMultiplier
+        };
+    }
+
     /** @override */
     prepareBaseData() {
         super.prepareBaseData();

--- a/src/module/actor/pokemon/document.js
+++ b/src/module/actor/pokemon/document.js
@@ -299,9 +299,36 @@ class PTUPokemonActor extends PTUActor {
         this.attributes.health.max = system.health.max;
 
         const calcLevelCap = (friendship) => Math.ceil(5 + (1.58 * ((this.trainer?.system.level.current ?? 0) * (["data-revamp", "short-track"].includes(game.settings.get("ptu", "variant.trainerAdvancement")) ? 2 : ["long-track"].includes(game.settings.get("ptu", "variant.trainerAdvancement")) ? 0.5 : 1))) + ((4 / 3) * (friendship) * Math.pow(1 + (((this.trainer?.system.level.current ?? 0) * (["data-revamp", "short-track"].includes(game.settings.get("ptu", "variant.trainerAdvancement")) ? 2 : ["long-track"].includes(game.settings.get("ptu", "variant.trainerAdvancement")) ? 0.5 : 1)) / 34), 2)));
+        
+        // Calculate EXP Training Level Cap: Trainer Level × Milestone Multiplier
+        // Milestone Multiplier = 2 + 2 × Milestones earned
+        const calcExpTrainingLevelCap = () => {
+            try {
+                const trainer = this.trainer;
+                if (!trainer) {
+                    return 6;
+                }
+                
+                // Use the trainer's dedicated EXP Training data method
+                const expData = trainer.getExpTrainingData();
+                
+                // Return the pre-calculated EXP Training Level Cap
+                const result = expData.expTrainingLevelCap;
+                
+                // Handle edge cases
+                if (isNaN(result) || result === null || result === undefined) {
+                    return 6;
+                }
+                
+                return result;
+            } catch (error) {
+                return 6;
+            }
+        };
+
         this.attributes.level.cap = {
             current: calcLevelCap(system.friendship ?? 0),
-            training: calcLevelCap(0),
+            training: calcExpTrainingLevelCap(),
         }
 
         /* The Corner of Exceptions */

--- a/src/module/apps/npc-quick-build/document.js
+++ b/src/module/apps/npc-quick-build/document.js
@@ -721,12 +721,18 @@ export class NpcQuickBuildData {
             species = await fromUuid(uuid);
         }
 
+        // Check if species is valid before proceeding
+        if (!species) {
+            console.warn(`PTU NPC Quick Build: Could not find species for UUID: ${uuid}`);
+            return;
+        }
+
         pkmn.species.uuid = uuid;
         pkmn.species.object = species;
         pkmn.species.name = species.name;
         // set available genders
         const genders = [];
-        const genderRatio = species.system.breeding.genderRatio;
+        const genderRatio = species.system?.breeding?.genderRatio ?? 50; // Default to 50/50 if undefined
         if (genderRatio == -1) {
             genders.push({
                 label: "PTU.Genderless",
@@ -756,7 +762,7 @@ export class NpcQuickBuildData {
         pkmn.species.gender.choosable = genders.length > 1;
 
         // get minimum level for this evolution
-        pkmn.level.min = species.system.evolutions.find(e => e.slug == species.system.slug)?.level ?? 1;
+        pkmn.level.min = species.system?.evolutions?.find(e => e.slug == species.system?.slug)?.level ?? 1;
         if (pkmn.level.value < pkmn.level.min) {
             pkmn.level.value = pkmn.level.min;
         }

--- a/system.json
+++ b/system.json
@@ -6,7 +6,7 @@
     "minimum": "13.345",
     "verified": "13.348"
   },
-  "version": "4.4.1",
+  "version": "4.4.2",
   "templateVersion": 2,
   "authors": [
     {
@@ -32,7 +32,8 @@
       "url": "https://www.youtube.com/channel/UCiUTs4FV0HtdoziFogJAdEw"
     },
     {
-      "name": "p-arth"
+      "name": "UmcaraAí",
+      "url": "https://github.com/p-arth"
     }
   ],
   "esmodules": ["src/ptr.js"],


### PR DESCRIPTION
This PR adds:
- Proper calculations for Exp Training Level Cap
- Incorporate new logic for Exp Training Level Cap for Pokémon sheet
- Fix issue where NPC Quick Build was loading forever